### PR TITLE
Allow seeding to work on Unix systems

### DIFF
--- a/amaznot/database/seeders/ProductSeeder.php
+++ b/amaznot/database/seeders/ProductSeeder.php
@@ -15,11 +15,11 @@ class ProductSeeder extends Seeder
      */
     public function run()
     {
-        $csvFile = fopen(__DIR__ . "\\amazon_clean_mini.csv", "r");
+        $csvFile = fopen(__DIR__ . "/amazon_clean_mini.csv", "r");
 
         $onFirstLine = true;
         $count = 0;
-        while(($data = fgetcsv($csvFile, 6000, ",")) !== false)
+        while(($data = fgetcsv($csvFile, 0, ",")) !== false)
         {
             try
             {


### PR DESCRIPTION
Modify product seeding script to work on both Windows and Unix systems, where file paths are represented in different formats.