### PR TITLE
#74 Generate HTTPS links by default in production

### DIFF
--- a/amaznot/app/Providers/AppServiceProvider.php
+++ b/amaznot/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +24,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        if($this->app->environment('production')) {
+            URL::forceScheme('https');
+        }
     }
 }

--- a/amaznot/resources/views/auth/register.blade.php
+++ b/amaznot/resources/views/auth/register.blade.php
@@ -37,7 +37,7 @@
 
             <div class="mb-4">
                 <label for="password_confirmation" class="sr-only">Confirm Password</label>
-                <input type="password_confirmation" name="password_confirmation" id="password_confirmation" placeholder = "Confirm Password"
+                <input type="password" name="password_confirmation" id="password_confirmation" placeholder = "Confirm Password"
                 class="form-control @error('password_confirmation') border-danger @enderror" value="">
             </div>
 


### PR DESCRIPTION
When in a production environment, all links will by default use HTTPS